### PR TITLE
Pass `#+ATTR_*' tags to pandoc to allow resizing of images.

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -211,7 +211,8 @@
   :type 'list)
 
 (org-export-define-derived-backend 'pandoc 'org
-  :translate-alist '((template . org-pandoc-template))
+  :translate-alist '((template . org-pandoc-template)
+                     (paragraph . org-pandoc-identity))
   ;; :export-block "PANDOC"
   :menu-entry
   `(?p "export via pandoc"
@@ -1295,6 +1296,14 @@ Option table is created in this stage."
     (if org-template
         (funcall org-template contents info)
     contents)))
+
+(defun org-pandoc-identity (blob contents info)
+  "Transcode BLOB element or object back into Org syntax.
+CONTENTS is its contents, as a string or nil. INFO is ignored.
+Like `org-org-identity', but also preserves #+ATTR_* tags in the
+output."
+  (ignore info)
+  (org-export-expand blob contents t))
 
 (defun org-pandoc-put-options (options)
   "Put alist OPTIONS to `org-pandoc-option-table'."


### PR DESCRIPTION
As per https://github.com/jgm/pandoc/issues/1906 and
https://github.com/jgm/pandoc/pull/2927 pandoc now supports the use of
`#+ATTR_HTML' tags to specify attributes (e.g., :width, :height) for
images when exporting from org-mode documents.

By default, `ox-pandoc' was parsing the document elements using
`org-org-indentity' (inherited from the 'org export backend), which
removes all #+ATTR_* tags from the output. This change puts them back in.

NOTE: seems to be undocumented, but #+ATTR_* tags appear to be classed
under the `paragraph' type in org-mode's export system.