### PR TITLE
Allow Tables/Figures/Equations etc. to be numbered in pandoc export

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -24,6 +24,7 @@
 (require 'dash)
 (require 'ht)
 (require 'cl-lib)
+(require 'ox-html) ; from `org', needed for `org-html-standalone-image-p'
 
 (defgroup org-pandoc nil
   "Options specific to Pandoc export back-end."
@@ -216,7 +217,7 @@
                      (link      . org-pandoc-link)
                      (table     . org-pandoc-table)
                      (template  . org-pandoc-template)
-                     (paragraph . org-pandoc-identity))
+                     (paragraph . org-pandoc-paragraph))
   ;; :export-block "PANDOC"
   :menu-entry
   `(?p "export via pandoc"
@@ -1397,6 +1398,18 @@ Option table is created in this stage."
     (if org-template
         (funcall org-template contents info)
     contents)))
+
+(defun org-pandoc-paragraph (paragraph contents info)
+  "Transcode a PARAGRAPH element from Org to Pandoc.
+CONTENTS is the contents of the paragraph, as a string.  INFO is
+the plist used as a communication channel."
+  (when (org-html-standalone-image-p paragraph info)
+    ;; Standalone image.
+    (org-pandoc-set-caption-title paragraph info "Figure %d:"
+                                  #'org-html-standalone-image-p))
+  ;; Export the paragraph verbatim. Like `org-org-identity', but also
+  ;; preserves #+ATTR_* tags in the output.
+  (org-export-expand paragraph contents t))
 
 (defun org-pandoc-identity (blob contents _info)
   "Transcode BLOB element or object back into Org syntax.

--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -1276,17 +1276,17 @@ table/figure/etc. numbers."
     ;; name-target would be, e.g., "<<tab:test-table>>"
     (when caption
       (if (member org-pandoc-format '(beamer beamer-pdf latex latex-pdf))
-          (setf (cl-caaar caption) (concat name-target (cl-caaar caption)))
+          (push name-target (caar caption))
         ;; Get sequence number of current src-block among every
         ;; src-block with a caption.  Additionally translate the caption
         ;; label into the local language.
-        (let ((reference (org-export-get-ordinal element info nil pred))
-              (title-fmt (org-export-translate fmt :utf-8 info)))
+        (let* ((reference (org-export-get-ordinal element info nil pred))
+               (title-fmt (org-export-translate fmt :utf-8 info))
+               (new-name-target (concat (format title-fmt reference) " " name-target)))
           ;; Set the text of the caption to have, e.g., 'Table <num>:
           ;; ' prepended. Also add a target for any hyperlinks to this
-          ;; table. Pandoc doesn't pick up #+LABEL: elements.
-          (setf (cl-caaar caption) (concat (format title-fmt reference)
-                                           " " name-target (cl-caaar caption))))))))
+          ;; table. Pandoc doesn't pick up #+LABEL: or #+NAME: elements.
+          (push new-name-target (caar caption)))))))
 
 (defun org-pandoc--numbered-equation-p (element _info)
   "Non-nil when ELEMENT is a numbered latex equation environment.

--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -217,7 +217,8 @@
                      (link      . org-pandoc-link)
                      (table     . org-pandoc-table)
                      (template  . org-pandoc-template)
-                     (paragraph . org-pandoc-paragraph))
+                     (paragraph . org-pandoc-paragraph)
+                     (src-block . org-pandoc-src-block))
   ;; :export-block "PANDOC"
   :menu-entry
   `(?p "export via pandoc"
@@ -1410,6 +1411,15 @@ the plist used as a communication channel."
   ;; Export the paragraph verbatim. Like `org-org-identity', but also
   ;; preserves #+ATTR_* tags in the output.
   (org-export-expand paragraph contents t))
+
+(defun org-pandoc-src-block (src-block contents info)
+  "Transcode a SRC-BLOCK element from Org to Pandoc.
+CONTENTS is the contents of the table. INFO is a plist holding
+contextual information."
+  (org-pandoc-set-caption-title src-block info "Listing %d:"
+                                #'org-pandoc--has-caption-p)
+  ;; Export the src-block with it's modified caption
+  (org-export-expand src-block contents t))
 
 (defun org-pandoc-identity (blob contents _info)
   "Transcode BLOB element or object back into Org syntax.


### PR DESCRIPTION
Fixes https://github.com/kawabata/ox-pandoc/issues/12

This works around a longstanding set of issues in pandoc, which doesn't support automatic numbering of Figures/Tables/Equations etc.

e.g.,
https://github.com/jgm/pandoc/issues/2328
https://github.com/jgm/pandoc/issues/615
https://github.com/jgm/pandoc/issues/2851
https://github.com/jgm/pandoc/issues/2077

These patches override the exporter to add appropriate numbered captions to Tables, Figures and source code Listings, as well as equation numbers to LaTeX math environments. The patches also implement correct numbered referencing when defining org-mode links to numbered items like Tables, Figures, Listings and Equations.

This functionality and behaviour should more closely mimic the standard org-mode exporters.