### PR TITLE
Fix check for markdown syntax-extensions

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -1459,7 +1459,7 @@ OPTIONS is a hashtable.  It runs asynchronously."
                format)))
          (args
           `("-f" "org"
-            "-t" ,(if (string-match output-format "^markdown")
+            "-t" ,(if (string-match "^markdown" output-format)
                       (concat output-format org-pandoc-markdown-extension)
                     output-format)
             ,@(and output-file

--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -20,6 +20,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
 (require 'ox-org)
 (require 'dash)
 (require 'ht)


### PR DESCRIPTION
I wasn't able to use

```elisp
  (setq org-pandoc-markdown-extension "+yaml_metadata_block")
```

because the paramaters for `string-match` were exchanged.
