### PR TITLE
Add --shift-heading-level-by to org-pandoc-valid-options

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -59,7 +59,7 @@
     metadata natbib no-highlight number-offset number-sections
     pdf-engine-opt pdf-engine preserve-tabs print-default-data-file
     print-default-template quiet reference-doc reference-links
-    reference-location resource-path section-divs self-contained
+    reference-location resource-path section-divs self-contained shift-heading-level-by
     slide-level standalone strip-comments syntax-definition tab-stop
     table-of-contents template title-prefix toc top-level-division
     toc-depth trace track-changes variable verbose version webtex wrap))


### PR DESCRIPTION
Adds this fine option in favour of --base-header-level which is deprecated. Tested locally and works just like that.